### PR TITLE
Beat Saber 1.40.8対応 & Zenject/SiraUtil対応リファクタ

### DIFF
--- a/BSWindowManager/BSWindowManager.csproj
+++ b/BSWindowManager/BSWindowManager.csproj
@@ -40,6 +40,16 @@
     <DisableZipRelease>True</DisableZipRelease>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="BeatSaber.ViewSystem, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatSaber.ViewSystem.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="BGLib.AppFlow, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.AppFlow.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="BSML">
       <HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
       <Private>False</Private>
@@ -48,6 +58,11 @@
     <Reference Include="BS_Utils, Version=1.8.0.0, Culture=neutral, processorArchitecture=MSIL">
       <Private>False</Private>
       <HintPath>$(BeatSaberDir)\Plugins\BS_Utils.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="SiraUtil, Version=3.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Plugins\SiraUtil.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System" />
@@ -99,6 +114,21 @@
     <Reference Include="UnityEngine.VRModule">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.VRModule.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="Zenject, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="Zenject-usage, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject-usage.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
+    <Reference Include="ZenjectExtension, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\ZenjectExtension.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/BSWindowManager/BSWindowManagerController.cs
+++ b/BSWindowManager/BSWindowManagerController.cs
@@ -1,4 +1,6 @@
-﻿using BSWindowManager.Configuration;
+﻿using BeatSaberMarkupLanguage.Settings;
+using BSWindowManager.Configuration;
+using BSWindowManager.UI;
 using BSWindowManager.Utils;
 using System;
 using System.Collections;
@@ -7,8 +9,10 @@ using System.ComponentModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using Zenject;
 
 namespace BSWindowManager
 {
@@ -16,28 +20,14 @@ namespace BSWindowManager
     /// Monobehaviours (scripts) are added to GameObjects.
     /// For a full list of Messages a Monobehaviour can receive from the game, see https://docs.unity3d.com/ScriptReference/MonoBehaviour.html.
     /// </summary>
-    public class BSWindowManagerController : MonoBehaviour
+    public class BSWindowManagerController
     {
-        public static BSWindowManagerController Instance { get; private set; }
-
         private bool _autoAvtive = false;
 
         // These methods are automatically called by Unity, you should remove any you aren't using.
         #region Monobehaviour Messages
-        /// <summary>
-        /// Only ever called once, mainly used to initialize variables.
-        /// </summary>
-        private void Awake()
+        public BSWindowManagerController()
         {
-            // For this particular MonoBehaviour, we only want one instance to exist at any time, so store a reference to it in a static property
-            //   and destroy any that are created while one already exists.
-            if (Instance != null) {
-                Plugin.Log?.Warn($"Instance of {GetType().Name} already exists, destroying.");
-                GameObject.DestroyImmediate(this);
-                return;
-            }
-            GameObject.DontDestroyOnLoad(this); // Don't destroy this object on scene changes
-            Instance = this;
             PluginConfig.Instance.OnReloadEvent -= this.Instance_OnChangedEvent;
             PluginConfig.Instance.OnReloadEvent += this.Instance_OnChangedEvent;
 
@@ -45,7 +35,7 @@ namespace BSWindowManager
             PluginConfig.Instance.OnChangedEvent += this.Instance_OnChangedEvent;
             SceneManager.activeSceneChanged += this.SceneManager_activeSceneChanged;
             this._autoAvtive = PluginConfig.Instance.AutoActive;
-            Plugin.Log?.Debug($"{name}: Awake()");
+            Plugin.Log?.Debug($"");
         }
 
         private void Instance_OnChangedEvent(PluginConfig obj)
@@ -69,17 +59,6 @@ namespace BSWindowManager
             catch (Exception e) {
                 Plugin.Log.Error(e);
             }
-        }
-
-        /// <summary>
-        /// Called when the script is being destroyed.
-        /// </summary>
-        private void OnDestroy()
-        {
-            Plugin.Log?.Debug($"{name}: OnDestroy()");
-            if (Instance == this)
-                Instance = null; // This MonoBehaviour is being destroyed, so set the static instance property to null.
-
         }
         #endregion
     }

--- a/BSWindowManager/Plugin.cs
+++ b/BSWindowManager/Plugin.cs
@@ -4,8 +4,10 @@ using BSWindowManager.UI;
 using IPA;
 using IPA.Config;
 using IPA.Config.Stores;
+using SiraUtil.Zenject;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using Zenject;
 using IPALogger = IPA.Logging.Logger;
 
 namespace BSWindowManager
@@ -16,49 +18,33 @@ namespace BSWindowManager
     {
         internal static Plugin Instance { get; private set; }
         internal static IPALogger Log { get; private set; }
-        [Init]
+        #region BSIPA Config
         /// <summary>
-        /// Called when the plugin is first loaded by IPA (either when the game starts or when the plugin is enabled if it starts disabled).
-        /// [Init] methods that use a Constructor or called before regular methods like InitWithConfig.
-        /// Only use [Init] with one Constructor.
+        /// Initializes the plugin with the specified configuration, logger, and dependency injection context.
         /// </summary>
-        public void Init(IPALogger logger)
+        /// <remarks>This method is called by the BSIPA framework during plugin initialization. It sets up
+        /// configuration, logging, and dependency injection for the plugin. Components are registered for both the menu
+        /// and application contexts.</remarks>
+        /// <param name="conf">The configuration object used to load and manage plugin settings. Cannot be null.</param>
+        /// <param name="logger">The logger instance used for recording informational and debug messages. Cannot be null.</param>
+        /// <param name="zenjector">The dependency injection context used to install plugin components. Cannot be null.</param>
+        [Init]
+        public void InitWithConfig(IPA.Config.Config conf, IPALogger logger, Zenjector zenjector)
         {
             Instance = this;
             Log = logger;
             Log.Info("BSWindowManager initialized.");
-        }
-
-        #region BSIPA Config
-        //Uncomment to use BSIPA's config
-        [Init]
-        public void InitWithConfig(IPA.Config.Config conf)
-        {
+            zenjector.Install(Location.Menu, z =>
+            {
+                z.BindInterfacesAndSelfTo<Setting>().FromNewComponentAsViewController().AsSingle().NonLazy();
+            });
+            zenjector.Install(Location.App, z =>
+            {
+                z.BindInterfacesAndSelfTo<BSWindowManagerController>().AsSingle().NonLazy();
+            });
             Configuration.PluginConfig.Instance = conf.Generated<Configuration.PluginConfig>();
             Log.Debug("Config loaded");
         }
-
         #endregion
-
-        [OnStart]
-        public void OnApplicationStart()
-        {
-            Log.Debug("OnApplicationStart");
-            new GameObject("BSWindowManagerController").AddComponent<BSWindowManagerController>();
-            new GameObject("Setting").AddComponent<BSMLSettings>();
-            BSEvents.earlyMenuSceneLoadedFresh += this.BSEvents_earlyMenuSceneLoadedFresh;
-        }
-
-        private void BSEvents_earlyMenuSceneLoadedFresh(ScenesTransitionSetupDataSO obj)
-        {
-            BSMLSettings.instance.AddSettingsMenu("BS WINDOW MANAGER", Setting.instance.ResourceName, Setting.instance);
-        }
-
-        [OnExit]
-        public void OnApplicationQuit()
-        {
-            Log.Debug("OnApplicationQuit");
-
-        }
     }
 }

--- a/BSWindowManager/Properties/AssemblyInfo.cs
+++ b/BSWindowManager/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.1.1")]
-[assembly: AssemblyFileVersion("0.1.1")]
+[assembly: AssemblyVersion("1.0.0")]
+[assembly: AssemblyFileVersion("1.0.0")]

--- a/BSWindowManager/UI/Setting.cs
+++ b/BSWindowManager/UI/Setting.cs
@@ -1,18 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using BeatSaberMarkupLanguage;
-using BeatSaberMarkupLanguage.Attributes;
-using BeatSaberMarkupLanguage.Components;
+﻿using BeatSaberMarkupLanguage.Attributes;
+using BeatSaberMarkupLanguage.Settings;
 using BeatSaberMarkupLanguage.ViewControllers;
 using BSWindowManager.Configuration;
-using UnityEngine;
+using System.Reflection;
+using Zenject;
 
 namespace BSWindowManager.UI
 {
-    internal class Setting : PersistentSingleton<Setting>, INotifyPropertyChanged
+    internal class Setting : BSMLAutomaticViewController, IInitializable
     {
         // For this method of setting the ResourceName, this class must be the first class in the file.
         public string ResourceName => string.Join(".", GetType().Namespace, "Setting.bsml");
@@ -29,16 +24,9 @@ namespace BSWindowManager.UI
             }
         }
 
-        public event PropertyChangedEventHandler PropertyChanged;
-
-        protected void NotifyPropertyChanged([CallerMemberName]string member = null)
+        public void Initialize()
         {
-            this.OnPropertyChanged(new PropertyChangedEventArgs(member));
-        }
-
-        protected virtual void OnPropertyChanged(PropertyChangedEventArgs e)
-        {
-            this.PropertyChanged?.Invoke(this, e);
+            BSMLSettings.Instance.AddSettingsMenu("BS WINDOW MANAGER", ResourceName, this);
         }
     }
 }

--- a/BSWindowManager/manifest.json
+++ b/BSWindowManager/manifest.json
@@ -3,12 +3,13 @@
   "id": "BSWindowManager",
   "name": "BSWindowManager",
   "author": "denpadokei",
-  "version": "0.1.1",
+  "version": "1.0.0",
   "description": "",
-  "gameVersion": "1.12.2",
+  "gameVersion": "1.40.8",
   "dependsOn": {
-    "BSIPA": "^4.1.3",
-    "BeatSaberMarkupLanguage": "^1.4.1"
+    "BSIPA": "^4.3.6",
+    "BeatSaberMarkupLanguage": "^1.12.5",
+    "SiraUtil": "^3.2.1"
   },
   "features": []
 }


### PR DESCRIPTION
Beat Saber 1.40.8および最新BSIPA/BSML/SiraUtilに対応。
プロジェクト参照・manifest依存関係を更新。
MonoBehaviour依存を廃止し、ZenjectによるDI管理に移行。
設定画面・コントローラの初期化もDI方式に統一。
ActiveWindowに詳細なデバッグログを追加し堅牢化。
全体的に最新環境向けの大規模リファクタリングを実施。